### PR TITLE
Fix post tests

### DIFF
--- a/tests/tests-post.js
+++ b/tests/tests-post.js
@@ -139,8 +139,10 @@ test( 'Post parent is retrieved correctly', function() {
 
 	// 2. Test fetching parent from if it is part of the same collection as the current post model.
 
-	var posts = new wp.api.collections.Posts();
-	posts.create( new wp.api.models.Post({ ID:1, title: 'Test Parent' }) );
+	var posts = new wp.api.collections.Posts([
+		new wp.api.models.Post({ ID:1, title: 'Test Parent' })
+	]);
+
 	var post2 = posts.create( testData );
 
 	equal( post2.parent().get('title'), 'Test Parent' );


### PR DESCRIPTION
Line 144 was commented out to fix an issue flagged by jshint - var is defined, but not used.

But this causes the test to fail. 

Instead the parent post model should be passed when creating  the collection and not assigned to a variable.

Also - added some comments & formatting.
