### PR TITLE
add build/js/wp-api.js to bower.json/main

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,5 +8,6 @@
     "qunit": "~1.14.0",
     "sinon-1.9.1": "http://sinonjs.org/releases/sinon-1.9.1.js",
     "sinon-qunit-1.0.0": "http://sinonjs.org/releases/sinon-qunit-1.0.0.js"
-  }
+  },
+  "main": "build/js/wp-api.js"
 }


### PR DESCRIPTION
I'm using `client-js` with bower + Browserify + debowerify. With this patch, you can specify `require` statement more cleanly in the body script.

```javascript
// before
require('bower_components/wp-api-js/build/js/wp-api.js');

// after
require('wp-api-js');
```

`main` option in `bower.json` is recommended by [official bower.json spec][spec]. Several other build tools use this such as grunt, webpack, and so on.

[spec]: https://github.com/bower/bower.json-spec