### PR TITLE
Pass ID via object when hydrating response.author, including embedded author object if available 

### DIFF
--- a/js/models.js
+++ b/js/models.js
@@ -44,7 +44,7 @@
 		 * @returns {*}.
 		 */
 		parse: function( response ) {
-			var timestamp;
+			var timestamp, authorAttributes;
 
 			// Parse dates into native Date objects.
 			_.each( parseableDates, function( key ) {
@@ -57,8 +57,14 @@
 			});
 
 			// Parse the author into a User object.
-			if ( 'undefined' !== typeof response.author ) {
-				response.author = new wp.api.models.User( response.author );
+			if ( 'undefined' !== typeof response.author && ! ( response.author instanceof wp.api.models.User ) ) {
+				if ( response._embedded && response._embedded.author ) {
+					authorAttributes = _.findWhere( response._embedded.author, { id: response.author } );
+				}
+				if ( ! authorAttributes ) {
+					authorAttributes = { id: response.author };
+				}
+				response.author = new wp.api.models.User( authorAttributes );
 			}
 
 			return response;


### PR DESCRIPTION
Include embedded author object if availableFixes issue where a Backbone model needs an attributes object to be passed into `wp.api.models.User()`, not a bare ID, when hydrating `response.author` in `TimeStampedMixin.parse()`.

Additionally, if the request includes `_embed`, then the embedded author object is supplied instead of just `{ id: response.author }`.