### PR TITLE
Ensure that wp-api JS in plugin overrides any existing JS registered

### DIFF
--- a/client-js.php
+++ b/client-js.php
@@ -5,10 +5,18 @@
 
 function json_api_client_js() {
 
-	wp_enqueue_script( 'wp-api', plugins_url( 'build/js/wp-api.js', __FILE__ ), array( 'jquery', 'underscore', 'backbone' ), '1.0', true );
+	$scripts = wp_scripts();
+	$src = plugins_url( 'build/js/wp-api.js', __FILE__ );
+	if ( isset( $scripts->registered['wp-api'] ) ) {
+		$scripts->registered['wp-api']->src = $src;
+	} else {
+		wp_register_script( 'wp-api', $src, array( 'jquery', 'underscore', 'backbone' ), '1.0', true );
+	}
 
 	$settings = array( 'root' => esc_url_raw( get_rest_url() ), 'nonce' => wp_create_nonce( 'wp_rest' ) );
 	wp_localize_script( 'wp-api', 'wpApiSettings', $settings );
+
+	wp_enqueue_script( 'wp-api' );
 }
 
 if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {


### PR DESCRIPTION
Fixes an apparent issue where the client JS plugin is installed using a plugin name that puts it alphabetically _after_ the WP-API plugin.