### PR TITLE
Create models before DOM ready if possible; add promises for when schema constructs

### DIFF
--- a/client-js.php
+++ b/client-js.php
@@ -13,10 +13,31 @@ function json_api_client_js() {
 		wp_register_script( 'wp-api', $src, array( 'jquery', 'underscore', 'backbone' ), '1.0', true );
 	}
 
+	/**
+	 * @var \WP_REST_Server $wp_rest_server
+	 */
+	global $wp_rest_server;
+	if ( empty( $wp_rest_server ) ) {
+		/** This filter is documented in wp-includes/rest-api.php */
+		$wp_rest_server_class = apply_filters( 'wp_rest_server_class', 'WP_REST_Server' );
+		$wp_rest_server = new $wp_rest_server_class();
+
+		/** This filter is documented in wp-includes/rest-api.php */
+		do_action( 'rest_api_init', $wp_rest_server );
+	}
+
+	$schema_request = new WP_REST_Request( 'GET', '/wp/v2' );
+	$schema_response = $wp_rest_server->dispatch( $schema_request );
+	$schema = null;
+	if ( ! $schema_response->is_error() ) {
+		$schema = $schema_response->get_data();
+	}
+
 	$settings = array(
 		'root' => esc_url_raw( get_rest_url() ),
 		'nonce' => wp_create_nonce( 'wp_rest' ),
 		'versionString' => 'wp/v2/',
+		'schema' => $schema,
 	);
 	wp_localize_script( 'wp-api', 'wpApiSettings', $settings );
 

--- a/client-js.php
+++ b/client-js.php
@@ -13,7 +13,11 @@ function json_api_client_js() {
 		wp_register_script( 'wp-api', $src, array( 'jquery', 'underscore', 'backbone' ), '1.0', true );
 	}
 
-	$settings = array( 'root' => esc_url_raw( get_rest_url() ), 'nonce' => wp_create_nonce( 'wp_rest' ) );
+	$settings = array(
+		'root' => esc_url_raw( get_rest_url() ),
+		'nonce' => wp_create_nonce( 'wp_rest' ),
+		'versionString' => 'wp/v2/',
+	);
 	wp_localize_script( 'wp-api', 'wpApiSettings', $settings );
 
 }

--- a/js/load.js
+++ b/js/load.js
@@ -11,7 +11,8 @@
 	/**
 	 * Initialize the wp-api, optionally passing the API root.
 	 *
-	 * @param {string} apiRoot The api root. Optional, defaults to wpApiSettings.root.
+	 * @param {string} [apiRoot] The api root. Optional, defaults to wpApiSettings.root.
+	 * @param {string} [versionString] The version string. Optional, defaults to wpApiSettings.root.
 	 */
 	wp.api.init = function( apiRoot, versionString ) {
 		var schemaModel,

--- a/js/load.js
+++ b/js/load.js
@@ -244,7 +244,10 @@
 		args = args || {};
 		attributes.apiRoot = args.apiRoot || wpApiSettings.root;
 		attributes.versionString = args.versionString || wpApiSettings.versionString;
-		attributes.schema = args.schema || wpApiSettings.schema;
+		attributes.schema = args.schema || null;
+		if ( ! attributes.schema && attributes.apiRoot === wpApiSettings.root && attributes.versionString === wpApiSettings.versionString ) {
+			attributes.schema = wpApiSettings.schema;
+		}
 
 		if ( ! initializedDeferreds[ attributes.apiRoot + attributes.versionString ] ) {
 			endpoint = wp.api.endpoints.findWhere( { apiRoot: attributes.apiRoot, versionString: attributes.versionString } );

--- a/js/load.js
+++ b/js/load.js
@@ -259,7 +259,7 @@
 				// Map the default endpoints, extending any already present items (including Schema model).
 				wp.api.models      = _.extend( endpoint.get( 'models' ), wp.api.models );
 				wp.api.collections = _.extend( endpoint.get( 'collections' ), wp.api.collections );
-				deferred.resolve();
+				deferred.resolveWith( wp.api, [ endpoint ] );
 			} );
 			initializedDeferreds[ attributes.apiRoot + attributes.versionString ] = promise;
 		}

--- a/js/load.js
+++ b/js/load.js
@@ -38,7 +38,7 @@
 			if ( model.get( 'schema' ) ) {
 
 				// Use schema supplied as model attribute.
-				model.schemaModel.set( model.get( 'schema' ) );
+				model.schemaModel.set( model.schemaModel.parse( model.get( 'schema' ) ) );
 			} else if ( ! _.isUndefined( sessionStorage ) && sessionStorage.getItem( 'wp-api-schema-model' + model.get( 'apiRoot' ) + model.get( 'versionString' ) ) ) {
 
 				// Used a cached copy of the schema model if available.
@@ -244,11 +244,11 @@
 		args = args || {};
 		attributes.apiRoot = args.apiRoot || wpApiSettings.root;
 		attributes.versionString = args.versionString || wpApiSettings.versionString;
+		attributes.schema = args.schema || wpApiSettings.schema;
 
 		if ( ! initializedDeferreds[ attributes.apiRoot + attributes.versionString ] ) {
-			endpoint = wp.api.endpoints.findWhere( attributes );
+			endpoint = wp.api.endpoints.findWhere( { apiRoot: attributes.apiRoot, versionString: attributes.versionString } );
 			if ( ! endpoint ) {
-				attributes.schema = args.schema || null;
 				endpoint = new Endpoint( attributes );
 				wp.api.endpoints.add( endpoint );
 			}

--- a/js/load.js
+++ b/js/load.js
@@ -194,7 +194,9 @@
 									parentName + '/' + this.parent + '/' +
 									routeName;
 						},
-						model: loadingObjects.models[collectionClassName],
+
+						// Specify the model that this collection contains.
+						model: loadingObjects.models[ collectionClassName ],
 
 						// Include a reference to the original route object.
 						route: collectionRoute,
@@ -211,7 +213,10 @@
 						// For the url of a root level collection, use a string.
 						url: routeModel.get( 'apiRoot' ) + routeModel.get( 'versionString' ) + routeName,
 
-						// Incldue a refence to the original route object.
+						// Specify the model that this collection contains.
+						model: loadingObjects.models[ collectionClassName ],
+
+						// Include a reference to the original route object.
 						route: collectionRoute,
 
 						// Include the array of route methods for easy reference.

--- a/js/load.js
+++ b/js/load.js
@@ -39,7 +39,7 @@
 		} else {
 
 			// Construct a new Schema model.
-			schemaModel = new wp.api.models.Schema(),
+			schemaModel = new wp.api.models.Schema();
 
 			// Fetch the schema information from the API.
 			schemaModel.fetch( {

--- a/js/load.js
+++ b/js/load.js
@@ -3,238 +3,267 @@
 
 	'use strict';
 
-	var endpointLoading;
+	var Endpoint, initializedDeferreds = {};
 
 	window.wp = window.wp || {};
 	wp.api = wp.api || {};
 
-	/**
-	 * Initialize the wp-api, optionally passing the API root.
-	 *
-	 * @param {string} [apiRoot] The api root. Optional, defaults to wpApiSettings.root.
-	 * @param {string} [versionString] The version string. Optional, defaults to wpApiSettings.root.
-	 */
-	wp.api.init = function( apiRoot, versionString ) {
-		var schemaModel,
-			apiConstructor;
+	Endpoint = Backbone.Model.extend({
+		defaults: {
+			apiRoot: wpApiSettings.root,
+			versionString: wp.api.versionString,
+			schema: null,
+			models: {},
+			collections: {}
+		},
 
-		wp.api.apiRoot       = apiRoot || wpApiSettings.root;
-		wp.api.versionString = versionString || wp.api.versionString;
-		wpApiSettings.root = wp.api.apiRoot;
+		initialize: function() {
+			var model = this, deferred;
 
-		/**
-		 * Construct and fetch the API schema.
-		 *
-		 * Use a session Storage cached version if available.
-		 */
-		apiConstructor = new jQuery.Deferred();
+			Backbone.Model.prototype.initialize.apply( model, arguments );
 
-		// Used a cached copy of the schema model if available.
-		if ( ! _.isUndefined( sessionStorage ) && sessionStorage.getItem( 'wp-api-schema-model' + apiRoot ) ) {
+			deferred = jQuery.Deferred();
+			model.schemaConstructed = deferred.promise();
 
-			// Grab the schema model from the sessionStorage cache.
-			schemaModel = new wp.api.models.Schema( JSON.parse( sessionStorage.getItem( 'wp-api-schema-model' + apiRoot ) ) );
+			model.schemaModel = new wp.api.models.Schema( null, {
+				apiRoot: model.get( 'apiRoot' ),
+				versionString: model.get( 'versionString' )
+			});
 
-			// Contruct the models and collections from the Schema model.
-			wp.api.constructFromSchema( schemaModel, apiConstructor );
-		} else {
+			model.schemaModel.once( 'change', function() {
+				model.constructFromSchema();
+				deferred.resolve( model );
+			} );
 
-			// Construct a new Schema model.
-			schemaModel = new wp.api.models.Schema();
+			if ( model.get( 'schema' ) ) {
 
-			// Fetch the schema information from the API.
-			schemaModel.fetch( {
-				/**
-				 * When the server return the schema model data, store the data in a sessionCache so we don't
-				 * have to retrieve it again for this session. Then, construct the models and collections based
-				 * on the schema model data.
-				 */
-				success: function( newSchemaModel ) {
+				// Use schema supplied as model attribute.
+				model.schemaModel.set( model.get( 'schema' ) );
+			} else if ( ! _.isUndefined( sessionStorage ) && sessionStorage.getItem( 'wp-api-schema-model' + model.get( 'apiRoot' ) + model.get( 'versionString' ) ) ) {
 
-					// Store a copy of the schema model in the session cache if available.
-					if ( ! _.isUndefined( sessionStorage ) ) {
-						sessionStorage.setItem( 'wp-api-schema-model' + apiRoot, JSON.stringify( newSchemaModel ) );
+				// Used a cached copy of the schema model if available.
+				model.schemaModel.set( model.schemaModel.parse( JSON.parse( sessionStorage.getItem( 'wp-api-schema-model' + model.get( 'apiRoot' ) + model.get( 'versionString' ) ) ) ) );
+			} else {
+				model.schemaModel.fetch({
+					/**
+					 * When the server return the schema model data, store the data in a sessionCache so we don't
+					 * have to retrieve it again for this session. Then, construct the models and collections based
+					 * on the schema model data.
+					 */
+					success: function( newSchemaModel ) {
+
+						// Store a copy of the schema model in the session cache if available.
+						if ( ! _.isUndefined( sessionStorage ) ) {
+							sessionStorage.setItem( 'wp-api-schema-model' + model.get( 'apiRoot' ) + model.get( 'versionString' ), JSON.stringify( newSchemaModel.toJSON() ) );
+						}
+					},
+
+					// @todo Handle the error condition.
+					error: function() {
 					}
+				});
+			}
+		},
 
-					// Contruct the models and collections from the Schema model.
-					wp.api.constructFromSchema( newSchemaModel, apiConstructor );
-				},
+		constructFromSchema: function() {
+			var routeModel = this, modelRoutes, collectionRoutes, schemaRoot, loadingObjects;
 
-				// @todo Handle the error condition.
-				error: function() {
+			/**
+			 * Iterate thru the routes, picking up models and collections to build. Builds two arrays,
+			 * one for models and one for collections.
+			 */
+			modelRoutes                = [];
+			collectionRoutes           = [];
+			schemaRoot                 = routeModel.get( 'apiRoot' ).replace( wp.api.utils.getRootUrl(), '' );
+			loadingObjects             = {};
+
+			/**
+			 * Tracking objects for models and collections.
+			 */
+			loadingObjects.models      = routeModel.get( 'models' );
+			loadingObjects.collections = routeModel.get( 'collections' );
+
+			_.each( routeModel.schemaModel.get( 'routes' ), function( route, index ) {
+
+				// Skip the schema root if included in the schema.
+				if ( index !== routeModel.get(' versionString' ) &&
+						index !== schemaRoot &&
+						index !== ( '/' + routeModel.get( 'versionString' ).slice( 0, -1 ) )
+				) {
+					/**
+					 * Single item models end with a regex/variable.
+					 *
+					 * @todo make model/collection logic more robust.
+					 */
+					if ( index.endsWith( '+)' ) ) {
+						modelRoutes.push( { index: index, route: route } );
+					} else {
+
+						// Collections end in a name.
+						if ( ! index.endsWith( 'me' ) ) {
+							collectionRoutes.push( { index: index, route: route } );
+						}
+					}
 				}
+			} );
+
+			/**
+			 * Construct the models.
+			 *
+			 * Base the class name on the route endpoint.
+			 */
+			_.each( modelRoutes, function( modelRoute ) {
+
+				// Extract the name and any parent from the route.
+				var modelClassName,
+						routeName  = wp.api.utils.extractRoutePart( modelRoute.index, 2 ),
+						parentName = wp.api.utils.extractRoutePart( modelRoute.index, 4 );
+
+				// If the model has a parent in its route, add that to its class name.
+				if ( '' !== parentName && parentName !== routeName ) {
+					modelClassName = wp.api.utils.capitalize( parentName ) + wp.api.utils.capitalize( routeName );
+					loadingObjects.models[ modelClassName ] = wp.api.WPApiBaseModel.extend( {
+
+						// Function that returns a constructed url based on the parent and id.
+						url: function() {
+							var url = routeModel.get( 'apiRoot' ) + routeModel.get( 'versionString' ) +
+									parentName +  '/' + this.get( 'parent' ) + '/' +
+									routeName;
+							if ( ! _.isUndefined( this.get( 'id' ) ) ) {
+								url +=  '/' + this.get( 'id' );
+							}
+							return url;
+						},
+
+						// Include a reference to the original route object.
+						route: modelRoute,
+
+						// Include the array of route methods for easy reference.
+						methods: modelRoute.route.methods
+					} );
+				} else {
+
+					// This is a model without a parent in its route
+					modelClassName = wp.api.utils.capitalize( routeName );
+					loadingObjects.models[ modelClassName ] = wp.api.WPApiBaseModel.extend( {
+
+						// Function that returns a constructed url based on the id.
+						url: function() {
+							var url = routeModel.get( 'apiRoot' ) + routeModel.get( 'versionString' ) + routeName;
+							if ( ! _.isUndefined( this.get( 'id' ) ) ) {
+								url +=  '/' + this.get( 'id' );
+							}
+							return url;
+						},
+
+						// Include a reference to the original route object.
+						route: modelRoute,
+
+						// Include the array of route methods for easy reference.
+						methods: modelRoute.route.methods
+					} );
+				}
+
+				// Add defaults to the new model, pulled form the endpoint
+				wp.api.decorateFromRoute( modelRoute.route.endpoints, loadingObjects.models[ modelClassName ] );
+
+				// @todo add
+			} );
+
+			/**
+			 * Construct the collections.
+			 *
+			 * Base the class name on the route endpoint.
+			 */
+			_.each( collectionRoutes, function( collectionRoute ) {
+
+				// Extract the name and any parent from the route.
+				var collectionClassName,
+						routeName  = collectionRoute.index.slice( collectionRoute.index.lastIndexOf( '/' ) + 1 ),
+						parentName = wp.api.utils.extractRoutePart( collectionRoute.index, 4 );
+
+				// If the collection has a parent in its route, add that to its class name/
+				if ( '' !== parentName && parentName !== routeName ) {
+
+					collectionClassName = wp.api.utils.capitalize( parentName ) + wp.api.utils.capitalize( routeName );
+					loadingObjects.collections[ collectionClassName ] = wp.api.WPApiBaseCollection.extend( {
+
+						// Function that returns a constructed url passed on the parent.
+						url: function() {
+							return routeModel.get( 'apiRoot' ) + routeModel.get( 'versionString' ) +
+									parentName + '/' + this.parent + '/' +
+									routeName;
+						},
+						model: loadingObjects.models[collectionClassName],
+
+						// Include a reference to the original route object.
+						route: collectionRoute,
+
+						// Include the array of route methods for easy reference.
+						methods: collectionRoute.route.methods
+					} );
+				} else {
+
+					// This is a collection without a parent in its route.
+					collectionClassName = wp.api.utils.capitalize( routeName );
+					loadingObjects.collections[ collectionClassName ] = wp.api.WPApiBaseCollection.extend( {
+
+						// For the url of a root level collection, use a string.
+						url: routeModel.get( 'apiRoot' ) + routeModel.get( 'versionString' ) + routeName,
+
+						// Incldue a refence to the original route object.
+						route: collectionRoute,
+
+						// Include the array of route methods for easy reference.
+						methods: collectionRoute.route.methods
+					} );
+				}
+
+				// Add defaults to the new model, pulled form the endpoint
+				wp.api.decorateFromRoute( collectionRoute.route.endpoints, loadingObjects.collections[ collectionClassName ] );
 			} );
 		}
 
-		return apiConstructor.promise();
+	});
 
-	};
+	wp.api.endpoints = new Backbone.Collection({
+		model: Endpoint
+	});
 
 	/**
-	 * Construct the models and collections from the Schema model.
+	 * Initialize the wp-api, optionally passing the API root.
 	 *
-	 * @param {wp.api.models.Schema}    Backbone model of the API schema.
-	 * @param {jQuery.Deferred.promise} A promise to send api load updates.
+	 * @param {object} [args]
+	 * @param {string} [args.apiRoot] The api root. Optional, defaults to wpApiSettings.root.
+	 * @param {string} [args.versionString] The version string. Optional, defaults to wpApiSettings.root.
+	 * @param {object} [args.schema] The schema. Optional, will be fetched from API if not provided.
 	 */
-	wp.api.constructFromSchema = function( model, apiConstructor ) {
-		/**
-		 * Iterate thru the routes, picking up models and collections to build. Builds two arrays,
-		 * one for models and one for collections.
-		 */
-		var modelRoutes                = [],
-			collectionRoutes           = [],
-			schemaRoot                 = wp.api.apiRoot.replace( wp.api.utils.getRootUrl(), '' ),
-			loadingObjects             = {};
+	wp.api.init = function( args ) {
+		var endpoint, attributes = {}, deferred, promise;
 
-		/**
-		 * Tracking objects for models and collections.
-		 */
-		loadingObjects.models      = {};
-		loadingObjects.collections = {};
+		args = args || {};
+		attributes.apiRoot = args.apiRoot || wpApiSettings.root;
+		attributes.versionString = args.versionString || wpApiSettings.versionString;
 
-		_.each( model.get( 'routes' ), function( route, index ) {
-
-			// Skip the schema root if included in the schema.
-			if ( index !== wp.api.versionString &&
-				 index !== schemaRoot &&
-				 index !== ( '/' + wp.api.versionString.slice( 0, -1 ) )
-			) {
-				/**
-				 * Single item models end with a regex/variable.
-				 *
-				 * @todo make model/collection logic more robust.
-				 */
-				if ( index.endsWith( '+)' ) ) {
-					modelRoutes.push( { index: index, route: route } );
-				} else {
-
-					// Collections end in a name.
-					if ( ! index.endsWith( 'me' ) ) {
-						collectionRoutes.push( { index: index, route: route } );
-					}
-				}
+		if ( ! initializedDeferreds[ attributes.apiRoot + attributes.versionString ] ) {
+			endpoint = wp.api.endpoints.findWhere( attributes );
+			if ( ! endpoint ) {
+				attributes.schema = args.schema || null;
+				endpoint = new Endpoint( attributes );
+				wp.api.endpoints.add( endpoint );
 			}
-		} );
+			deferred = jQuery.Deferred();
+			promise = deferred.promise();
 
-		/**
-		 * Construct the models.
-		 *
-		 * Base the class name on the route endpoint.
-		 */
-		_.each( modelRoutes, function( modelRoute ) {
-
-			// Extract the name and any parent from the route.
-			var modelClassName,
-				routeName  = wp.api.utils.extractRoutePart( modelRoute.index, 2 ),
-				parentName = wp.api.utils.extractRoutePart( modelRoute.index, 4 );
-
-			// If the model has a parent in its route, add that to its class name.
-			if ( '' !== parentName && parentName !== routeName ) {
-				modelClassName = wp.api.utils.capitalize( parentName ) + wp.api.utils.capitalize( routeName );
-				loadingObjects.models[ modelClassName ] = wp.api.WPApiBaseModel.extend( {
-
-					// Function that returns a constructed url based on the parent and id.
-					url: function() {
-						var url = wp.api.apiRoot + wp.api.versionString +
-							parentName +  '/' + this.get( 'parent' ) + '/' +
-							routeName;
-						if ( ! _.isUndefined( this.get( 'id' ) ) ) {
-							url +=  '/' + this.get( 'id' );
-						}
-						return url;
-					},
-
-					// Incldue a refence to the original route object.
-					route: modelRoute,
-
-					// Include the array of route methods for easy reference.
-					methods: modelRoute.route.methods
-				} );
-			} else {
-
-				// This is a model without a parent in its route
-				modelClassName = wp.api.utils.capitalize( routeName );
-				loadingObjects.models[ modelClassName ] = wp.api.WPApiBaseModel.extend( {
-
-					// Function that returns a constructed url based on the id.
-					url: function() {
-						var url = wp.api.apiRoot + wp.api.versionString + routeName;
-						if ( ! _.isUndefined( this.get( 'id' ) ) ) {
-							url +=  '/' + this.get( 'id' );
-						}
-						return url;
-					},
-
-					// Incldue a refence to the original route object.
-					route: modelRoute,
-
-					// Include the array of route methods for easy reference.
-					methods: modelRoute.route.methods
-				} );
-			}
-
-			// Add defaults to the new model, pulled form the endpoint
-			wp.api.decorateFromRoute( modelRoute.route.endpoints, loadingObjects.models[ modelClassName ] );
-
-			// @todo add
-		} );
-
-		/**
-		 * Construct the collections.
-		 *
-		 * Base the class name on the route endpoint.
-		 */
-		_.each( collectionRoutes, function( collectionRoute ) {
-
-			// Extract the name and any parent from the route.
-			var collectionClassName,
-				routeName  = collectionRoute.index.slice( collectionRoute.index.lastIndexOf( '/' ) + 1 ),
-				parentName = wp.api.utils.extractRoutePart( collectionRoute.index, 4 );
-
-			// If the collection has a parent in its route, add that to its class name/
-			if ( '' !== parentName && parentName !== routeName ) {
-
-				collectionClassName = wp.api.utils.capitalize( parentName ) + wp.api.utils.capitalize( routeName );
-				loadingObjects.collections[ collectionClassName ] = wp.api.WPApiBaseCollection.extend( {
-
-					// Function that returns a constructed url pased on the parent.
-					url: function() {
-						return wp.api.apiRoot + wp.api.versionString +
-						parentName + '/' + this.parent + '/' +
-						routeName;
-					},
-					model: loadingObjects.models[collectionClassName],
-
-					// Incldue a refence to the original route object.
-					route: collectionRoute,
-
-					// Include the array of route methods for easy reference.
-					methods: collectionRoute.route.methods
-				} );
-			} else {
-
-				// This is a collection without a parent in its route.
-				collectionClassName = wp.api.utils.capitalize( routeName );
-				loadingObjects.collections[ collectionClassName ] = wp.api.WPApiBaseCollection.extend( {
-
-					// For the url of a root level collection, use a string.
-					url: wp.api.apiRoot + wp.api.versionString + routeName,
-
-							// Incldue a refence to the original route object.
-							route: collectionRoute,
-
-							// Include the array of route methods for easy reference.
-							methods: collectionRoute.route.methods
-						} );
-			}
-
-			// Add defaults to the new model, pulled form the endpoint
-			wp.api.decorateFromRoute( collectionRoute.route.endpoints, loadingObjects.collections[ collectionClassName ] );
-		} );
-
-		_.defer( function() {
-			apiConstructor.resolve( loadingObjects );
-		} );
+			endpoint.schemaConstructed.done( function( endpoint ) {
+				// Map the default endpoints, extending any already present items (including Schema model).
+				wp.api.models      = _.extend( endpoint.get( 'models' ), wp.api.models );
+				wp.api.collections = _.extend( endpoint.get( 'collections' ), wp.api.collections );
+				deferred.resolve();
+			} );
+			initializedDeferreds[ attributes.apiRoot + attributes.versionString ] = promise;
+		}
+		return initializedDeferreds[ attributes.apiRoot + attributes.versionString ];
 	};
 
 	/**
@@ -306,20 +335,8 @@
 	/**
 	 * Construct the default endpoints and add to an endpoints collection.
 	 */
-	wp.api.endpoints = new Backbone.Collection();
 
 	// The wp.api.init function returns a promise that will resolve with the endpoint once it is ready.
-	endpointLoading = wp.api.init();
-
-	// When the endpoint is loaded, complete the setup process.
-	endpointLoading.done( function( endpoint ) {
-
-		// Map the default endpoints, extending any already present items (including Schema model).
-		wp.api.models      = _.extend( endpoint.models, wp.api.models );
-		wp.api.collections = _.extend( endpoint.collections, wp.api.collections );
-
-		// Add the endpoint to the endpoints collection.
-		wp.api.endpoints.push( endpoint );
-	} );
+	wp.api.init();
 
 })( window );

--- a/js/models.js
+++ b/js/models.js
@@ -201,6 +201,7 @@
 
 			initialize: function( attributes, options ) {
 				var model = this;
+				options = options || {};
 
 				wp.api.WPApiBaseModel.prototype.initialize.call( model, attributes, options );
 

--- a/js/models.js
+++ b/js/models.js
@@ -193,8 +193,23 @@
 	wp.api.models.Schema = wp.api.WPApiBaseModel.extend(
 		/** @lends Schema.prototype  */
 		{
+			defaults: {
+				_links: {},
+				namespace: null,
+				routes: {}
+			},
+
+			initialize: function( attributes, options ) {
+				var model = this;
+
+				wp.api.WPApiBaseModel.prototype.initialize.call( model, attributes, options );
+
+				model.apiRoot = options.apiRoot || wpApiSettings.root;
+				model.versionString = options.versionString || wpApiSettings.versionString;
+			},
+
 			url: function() {
-				return wpApiSettings.root + wp.api.versionString;
+				return this.apiRoot + this.versionString;
 			}
 		}
 	);

--- a/js/models.js
+++ b/js/models.js
@@ -191,7 +191,7 @@
 	 * API Schema model. Contains meta information about the API.
 	 */
 	wp.api.models.Schema = wp.api.WPApiBaseModel.extend(
-		/** @lends Shema.prototype  */
+		/** @lends Schema.prototype  */
 		{
 			url: function() {
 				return wpApiSettings.root + wp.api.versionString;


### PR DESCRIPTION
The changes here will ensure that the Backbone models for the WPI API will be constructed before DOM ready if the JS is enqueued via WordPress so that the schema can be exported as script data. If the schema is not available in the initial PHP response, it will fallback to looking for a schema in `sessionStorage`. Otherwise, it will fetch the schema from the server.

The `wp.api.init()` function now returns a promise which resolves when the models are constructed and extended onto `wp.api.models` and `wp.api.collections`. This `wp.api.init()` function also takes an `args` param which allows you to initialize additional endpoints other than the default (which is initialized automatically). For example:

```js
wp.api.init( { apiRoot: 'http://other-site.example.com/wp-json/' } ).done( function( endpoint ) {
    // now use the models it provides on wp.api.models or via endpoint.get( 'models' )
} );
```

Calling `wp.api.init()` repeatedly for a given endpoint will only initialize the route once: the same promise will be returned for each invocation.

This introduces a new `Endpoint` model which contains a `Schema` model instance. I'm not 100% confident with how these are are organized.