### PR TITLE
Helper improvements: add setCategories, revise getCategories, returns promise

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -56,7 +56,7 @@ module.exports = function( grunt ) {
 			files: [
 				'js/*.js'
 			],
-			tasks: [ 'jshint', 'uglify:js', 'concat:js' ]
+			tasks: [ 'jshint', 'jscs', 'uglify:js', 'concat:js' ]
 		},
 		jscs: {
 			src: 'js/*.js',

--- a/js/load.js
+++ b/js/load.js
@@ -161,10 +161,6 @@
 							}
 						}
 					} );
-
-
-
-
 				} else {
 
 					// This is a model without a parent in its route
@@ -438,9 +434,49 @@
 						} } );
 					}
 
-
 					// Return the constructed categories.
 					return categories;
+				},
+
+				/**
+				 * Set the categories for a post.
+				 *
+				 * Accepts an array of category slugs, or a PostsCategories collection.
+				 *
+				 * @param {array|Backbone.Collection} categories The categories to set on the post.
+				 *
+				 */
+				setCategories: function( categories ) {
+					var existingCategories, allCategories, removedCategories, addedCategories,
+						newCategories = [];
+
+					// If this is an array of slugs, build a collection
+					if ( _.isArray( categories ) ) {
+
+						// Get all the categories
+						allCategories = new wp.api.collections.Categories();
+						allCategories.fetch();
+
+						_.each( categories, function( category ) {
+							newCategories.push( allCategories.findWhere( { slug: category } ) );
+						} );
+						categories = new wp.api.collections.PostsCategories( newCategories.toJSON(), '' );
+					}
+
+					// Get the existing categories.
+					existingCategories = this.getCategories();
+
+					// Calculate which categories have been removed or added (leave the rest).
+					removedCategories = _.difference( existingCategories, categories );
+					addedCategories   = _.difference( categories, existingCategories );
+
+					// Remove the removed categories.
+					existingCategories.remove( removedCategories );
+
+					// Add the added categories.
+					_.each( addedCategories, function( addedCategory ) {
+						existingCategories.create( addedCategory );
+					} );
 				}
 			},
 

--- a/js/load.js
+++ b/js/load.js
@@ -138,9 +138,32 @@
 						// Include a reference to the original route object.
 						route: modelRoute,
 
+						// Include a reference to the original class name.
+						name: modelClassName,
+
 						// Include the array of route methods for easy reference.
-						methods: modelRoute.route.methods
+						methods: modelRoute.route.methods,
+
+						initialize: function() {
+							/**
+							 * Posts and pages support trashing, other types don't support a trash
+							 * and require that you pass ?force=true to actually delete them.
+							 *
+							 * @todo we should be getting trashability from the Schema, not hard coding types here.
+							 */
+							if (
+								'Posts' !== this.name &&
+								'Pages' !== this.name &&
+								_.contains( this.methods, 'DELETE' )
+							) {
+								this.requireForceForDelete = true;
+							}
+						}
 					} );
+
+
+
+
 				} else {
 
 					// This is a model without a parent in its route
@@ -158,6 +181,9 @@
 
 						// Include a reference to the original route object.
 						route: modelRoute,
+
+						// Include a reference to the original class name.
+						name: modelClassName,
 
 						// Include the array of route methods for easy reference.
 						methods: modelRoute.route.methods
@@ -197,6 +223,9 @@
 						// Specify the model that this collection contains.
 						model: loadingObjects.models[ collectionClassName ],
 
+						// Include a reference to the original class name.
+						name: collectionClassName,
+
 						// Include a reference to the original route object.
 						route: collectionRoute,
 
@@ -214,6 +243,9 @@
 
 						// Specify the model that this collection contains.
 						model: loadingObjects.models[ collectionClassName ],
+
+						// Include a reference to the original class name.
+						name: collectionClassName,
 
 						// Include a reference to the original route object.
 						route: collectionRoute,
@@ -396,8 +428,15 @@
 
 					// If we didn’t have embedded categories, fetch the categories data.
 					if ( _.isUndefined( categories.models[0] ) ) {
-						categories.fetch();
+						categories.fetch( { success: function( collection ) {
+
+							// Attach post_parent id to the categories.
+							_.each( collection.models, function( category ) {
+								category.set( 'parent_post', postId );
+							} );
+						} } );
 					}
+
 
 					// Return the constructed categories.
 					return categories;

--- a/js/load.js
+++ b/js/load.js
@@ -127,7 +127,8 @@
 						// Function that returns a constructed url based on the parent and id.
 						url: function() {
 							var url = routeModel.get( 'apiRoot' ) + routeModel.get( 'versionString' ) +
-									parentName +  '/' + this.get( 'parent' ) + '/' +
+									parentName +  '/' +
+									( 0 === this.get( 'parent' ) ? this.get( 'parent_post' ) : this.get( 'parent' ) ) + '/' +
 									routeName;
 							if ( ! _.isUndefined( this.get( 'id' ) ) ) {
 								url +=  '/' + this.get( 'id' );

--- a/js/load.js
+++ b/js/load.js
@@ -450,10 +450,10 @@
 					var existingCategories, allCategories, removedCategories, addedCategories,
 						newCategories = [];
 
-					// If this is an array of slugs, build a collection
+					// If this is an array of slugs, build a collection.
 					if ( _.isArray( categories ) ) {
 
-						// Get all the categories
+						// Get all the categories.
 						allCategories = new wp.api.collections.Categories();
 						allCategories.fetch();
 

--- a/js/load.js
+++ b/js/load.js
@@ -481,7 +481,7 @@
 									// Tie the new category to the post.
 									newCategory.set( 'parent_post', self.get( 'id' ) );
 
-									// Add the new category to the collection
+									// Add the new category to the collection.
 									newCategories.push( newCategory );
 								} );
 								categories = new wp.api.collections.PostsCategories( newCategories );

--- a/js/models.js
+++ b/js/models.js
@@ -40,6 +40,10 @@
 					};
 				}
 
+				// Add '?force=true' to delete method when required.
+				if ( this.requireForceForDelete && 'delete' === method ) {
+					model.url = model.url() + '?force=true';
+				}
 				return Backbone.sync( method, model, options );
 			},
 


### PR DESCRIPTION
* Enables category deletion from PostsCategories collections
* Adds `setCategories` helper method that sets categories for a post - accepts a collection of categories or an array of category slugs
* Adds jscs to build