### PR TITLE
Remove dependecies on localized variables

### DIFF
--- a/js/collections.js
+++ b/js/collections.js
@@ -1,7 +1,8 @@
-/* global wpApiSettings:false */
-(function( wp, wpApiSettings, Backbone, _, window, undefined ) {
+( function() {
 
 	'use strict';
+
+	var wpApiSettings = window.wpApiSettings || {};
 
 	/**
 	 * Contains basic collection functionality such as pagination.
@@ -137,4 +138,4 @@
 		}
 	);
 
-})( wp, wpApiSettings, Backbone, _, window );
+} )();

--- a/js/load.js
+++ b/js/load.js
@@ -1,12 +1,15 @@
-/* global wpApiSettings */
-(function( window, undefined ) {
+( function() {
 
 	'use strict';
 
-	var Endpoint, initializedDeferreds = {};
-
+	var Endpoint, initializedDeferreds = {},
+		wpApiSettings = window.wpApiSettings || {};
 	window.wp = window.wp || {};
-	wp.api = wp.api || {};
+	wp.api    = wp.api || {};
+
+	if ( _.isEmpty( wpApiSettings ) ) {
+		wpApiSettings.root = window.location.origin + '/wp-json/';
+	}
 
 	Endpoint = Backbone.Model.extend({
 		defaults: {
@@ -363,4 +366,4 @@
 	// The wp.api.init function returns a promise that will resolve with the endpoint once it is ready.
 	wp.api.init();
 
-})( window );
+} )();

--- a/js/models.js
+++ b/js/models.js
@@ -2,9 +2,11 @@
 
 // Suppress warning about parse function's unused "options" argument:
 /* jshint unused:false */
-(function( wp, wpApiSettings, Backbone, window, undefined ) {
+(function() {
 
 	'use strict';
+
+	var wpApiSettings = window.wpApiSettings || {};
 
 	/**
 	 * Backbone base model for all models.
@@ -111,4 +113,4 @@
 			}
 		}
 	);
-})( wp, wpApiSettings, Backbone, window );
+})();


### PR DESCRIPTION
* when wpApiSettings is not loaclized, script will attempt to load schema from its origin " '/wp-json/'
* Enables enqueueing of script from remote sites