### PR TITLE
Fix post saving

### DIFF
--- a/js/models.js
+++ b/js/models.js
@@ -27,6 +27,16 @@
 
 				options = options || {};
 
+				// Remove date_gmt if null.
+				if ( _.isNull( model.get( 'date_gmt' ) ) ) {
+					model.unset( 'date_gmt' );
+				}
+
+				// Remove slug if empty.
+				if ( _.isEmpty( model.get( 'slug' ) ) ) {
+					model.unset( 'slug' );
+				}
+
 				if ( ! _.isUndefined( wpApiSettings.nonce ) && ! _.isNull( wpApiSettings.nonce ) ) {
 					beforeSend = options.beforeSend;
 

--- a/js/models.js
+++ b/js/models.js
@@ -42,7 +42,7 @@
 					};
 				}
 
-				// Add '?force=true' to delete method when required.
+				// Add '?force=true' to use delete method when required.
 				if ( this.requireForceForDelete && 'delete' === method ) {
 					model.url = model.url() + '?force=true';
 				}


### PR DESCRIPTION
Sending the API back a new post's blank slug and null date_gmt values causes validation errors. For now, strip these invalid values. 

See https://github.com/WP-API/WP-API/pull/2303