### PR TITLE
Fixes/session storage in private mode

### DIFF
--- a/js/load.js
+++ b/js/load.js
@@ -57,7 +57,12 @@
 
 						// Store a copy of the schema model in the session cache if available.
 						if ( ! _.isUndefined( sessionStorage ) ) {
-							sessionStorage.setItem( 'wp-api-schema-model' + model.get( 'apiRoot' ) + model.get( 'versionString' ), JSON.stringify( newSchemaModel ) );
+							try {
+								sessionStorage.setItem( 'wp-api-schema-model' + model.get( 'apiRoot' ) + model.get( 'versionString' ), JSON.stringify( newSchemaModel ) );
+							} catch ( error ) {
+
+								// Fail silently, fixes errors in safari private mode.
+							}
 						}
 					},
 


### PR DESCRIPTION
Wrapping the use of `sessionStorage` in a try/catch block to avoid error messages when in safari private mode.

Fixes https://github.com/WP-API/client-js/issues/122.