### PR TITLE
Make sessionStorage optional

### DIFF
--- a/client-js.php
+++ b/client-js.php
@@ -48,6 +48,15 @@ function json_api_client_js() {
 		'schema'        => $schema,
 		'cacheSchema'   => true,
 	);
+
+	/**
+	 * Filter the JavaScript Client settings before localizing.
+	 *
+	 * Enables modifying the config values sent to the JS client.
+	 *
+	 * @param array  $settings The JS Client settings.
+	 */
+	$settings = apply_filters( 'rest_js_client_settings', $settings );
 	wp_localize_script( 'wp-api', 'wpApiSettings', $settings );
 
 }

--- a/client-js.php
+++ b/client-js.php
@@ -46,6 +46,7 @@ function json_api_client_js() {
 		'nonce'         => wp_create_nonce( 'wp_rest' ),
 		'versionString' => 'wp/v2/',
 		'schema'        => $schema,
+		'cacheSchema'   => true,
 	);
 	wp_localize_script( 'wp-api', 'wpApiSettings', $settings );
 

--- a/js/load.js
+++ b/js/load.js
@@ -47,7 +47,7 @@
 
 				// Use schema supplied as model attribute.
 				model.schemaModel.set( model.schemaModel.parse( model.get( 'schema' ) ) );
-			} else if ( ! _.isUndefined( sessionStorage ) && sessionStorage.getItem( 'wp-api-schema-model' + model.get( 'apiRoot' ) + model.get( 'versionString' ) ) ) {
+			} else if ( ! _.isUndefined( sessionStorage ) && wpApiSettings.cacheSchema && sessionStorage.getItem( 'wp-api-schema-model' + model.get( 'apiRoot' ) + model.get( 'versionString' ) ) ) {
 
 				// Used a cached copy of the schema model if available.
 				model.schemaModel.set( model.schemaModel.parse( JSON.parse( sessionStorage.getItem( 'wp-api-schema-model' + model.get( 'apiRoot' ) + model.get( 'versionString' ) ) ) ) );
@@ -61,7 +61,7 @@
 					success: function( newSchemaModel ) {
 
 						// Store a copy of the schema model in the session cache if available.
-						if ( ! _.isUndefined( sessionStorage ) ) {
+						if ( ! _.isUndefined( sessionStorage ) && wpApiSettings.cacheSchema ) {
 							try {
 								sessionStorage.setItem( 'wp-api-schema-model' + model.get( 'apiRoot' ) + model.get( 'versionString' ), JSON.stringify( newSchemaModel ) );
 							} catch ( error ) {


### PR DESCRIPTION
* Add a `cacheSchema` option to the settings to determine if sessionStorage should be used to cache the schema.
* Add a PHP filter for the js client settings.