### PR TITLE
Model detection bug

### DIFF
--- a/js/load.js
+++ b/js/load.js
@@ -145,7 +145,7 @@
 				) {
 
 					// Single items end with a regex (or the special case 'me').
-					if ( /.*\/(?>me|\(.*\))$/.test( index ) ) {
+					if ( /.*\/(me|\(.*\))$/.test( index ) ) {
 						modelRoutes.push( { index: index, route: route } );
 					} else {
 

--- a/js/load.js
+++ b/js/load.js
@@ -145,7 +145,7 @@
 				) {
 
 					// Single items end with a regex (or the special case 'me').
-					if ( /(?:.*[+)]|\/me)$/.test( index ) ) {
+					if ( /.*\/(?>me|\(.*\))$/.test( index ) ) {
 						modelRoutes.push( { index: index, route: route } );
 					} else {
 


### PR DESCRIPTION
Currently the regex for detecting the `/me` endpoint is too loose. If an endpoint is, for example `/team` matches the characters 'm' and 'e' without even needing to be in any particular order. The new regex is strict in that it must be `/me` or `/(id stuff)`.