### PR TITLE
Fix incoming dates which aren't in UTC

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -246,7 +246,11 @@
 				 * @returns {*}.
 				 */
 				parse: function( response ) {
-					var timestamp;
+					var timestamp,
+
+					// The API returns two dates for a post: date and date_gmt. The difference
+					// between these times equals difference between the timezone and UTC.
+					utcOffset = ( new Date( response.date_gmt ).getTime() - new Date( response.date ).getTime() );
 
 					// Parse dates into native Date objects.
 					_.each( parseableDates, function( key ) {
@@ -257,7 +261,13 @@
 						// Don't convert null values.
 						if ( ! _.isNull( response[ key ] ) ) {
 							timestamp = wp.api.utils.parseISO8601( response[ key ] );
-							response[ key ] = new Date( timestamp );
+
+							// Adjust date and mofified dates to put them in UTC.
+							if ( 'date' === key || 'date_modified' === key ) {
+								response[ key ] = new Date( timestamp + utcOffset );
+							} else {
+								response[ key ] = new Date( timestamp );
+							}
 						}
 					});
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -250,7 +250,7 @@
 
 					// The API returns two dates for a post: date and date_gmt. The difference
 					// between these times equals difference between the timezone and UTC.
-					utcOffset = ( new Date( response.date_gmt ).getTime() - new Date( response.date ).getTime() );
+					utcOffset = _.isNull( response.date_gmt ) ? 0 : ( new Date( response.date_gmt ).getTime() - new Date( response.date ).getTime() );
 
 					// Parse dates into native Date objects.
 					_.each( parseableDates, function( key ) {

--- a/js/utils.js
+++ b/js/utils.js
@@ -262,12 +262,12 @@
 						if ( ! _.isNull( response[ key ] ) ) {
 							timestamp = wp.api.utils.parseISO8601( response[ key ] );
 
-							// Adjust date and mofified dates to put them in UTC.
+							// Adjust date and date_modified to put them in UTC.
 							if ( 'date' === key || 'date_modified' === key ) {
-								response[ key ] = new Date( timestamp + utcOffset );
-							} else {
-								response[ key ] = new Date( timestamp );
+								timestamp += utcOffset;
 							}
+
+							response[ key ] = new Date( timestamp );
 						}
 					});
 

--- a/tests/tests-post.js
+++ b/tests/tests-post.js
@@ -1,29 +1,5 @@
 module( 'WP-API JS Client Tests' );
 
-// Test updating a post to verify the date is unchanged.
-QUnit.test( 'Testing dates when updating posts.' , function( assert ) {
-	var done = assert.async();
-	assert.expect( 1 );
-
-	wp.api.loadPromise.done( function() {
-
-		var post = new wp.api.models.Post( {id: 1} );
-		post.fetch().done( function() {
-
-			var date = post.get( 'date' );
-
-			post.save().done( function() {
-				// Get the post one more time to check its date.
-				var post = new wp.api.models.Post( {id: 1} );
-				post.fetch().done( function() {
-					assert.equal( post.get( 'date' ).getTime(), date.getTime(), 'The date should not change when a post is updated.' );
-					done();
-				} );
-			} );
-		} );
-	} );
-} );
-
 QUnit.test( 'API Loaded correctly', function( assert ) {
 	var done = assert.async();
 


### PR DESCRIPTION
The API returns two dates for a post: date and date_gmt. The difference between these times equals difference between the timezone and UTC. Add tis difference to date and date_modified before creating JavaScript date