### PR TITLE
WP-API JS client can't use getCategories for models returned by collections

### DIFF
--- a/js/load.js
+++ b/js/load.js
@@ -276,13 +276,16 @@
 
 						// Function that returns a constructed url passed on the parent.
 						url: function() {
+
 							return routeModel.get( 'apiRoot' ) + routeModel.get( 'versionString' ) +
 									parentName + '/' + this.parent + '/' +
 									routeName;
 						},
 
 						// Specify the model that this collection contains.
-						model: loadingObjects.models[ modelClassName ],
+						model: function( attrs, options ) {
+							return new loadingObjects.models[ modelClassName ]( attrs, options );
+						},
 
 						// Include a reference to the original class name.
 						name: collectionClassName,
@@ -305,7 +308,9 @@
 						url: routeModel.get( 'apiRoot' ) + routeModel.get( 'versionString' ) + routeName,
 
 						// Specify the model that this collection contains.
-						model: loadingObjects.models[ modelClassName ],
+						model: function( attrs, options ) {
+							return new loadingObjects.models[ modelClassName ]( attrs, options );
+						},
 
 						// Include a reference to the original class name.
 						name: collectionClassName,

--- a/js/load.js
+++ b/js/load.js
@@ -276,7 +276,6 @@
 
 						// Function that returns a constructed url passed on the parent.
 						url: function() {
-
 							return routeModel.get( 'apiRoot' ) + routeModel.get( 'versionString' ) +
 									parentName + '/' + this.parent + '/' +
 									routeName;


### PR DESCRIPTION
Fix an issue where models automatically created for fetched collections didn't have appropriate mixin methods, like `.getCategories`, applied. Resolved by defining the model property of collections as a function returning an new instantiated model, instead of a static model prototype.

Props jesseenterprises.

See https://core.trac.wordpress.org/ticket/39070