### PR TITLE
Ensure base initialize method called when subclassing WPApiBaseModel

### DIFF
--- a/js/load.js
+++ b/js/load.js
@@ -202,7 +202,8 @@
 						// Include the array of route methods for easy reference.
 						methods: modelRoute.route.methods,
 
-						initialize: function() {
+						initialize: function( attributes, options ) {
+							wp.api.WPApiBaseModel.prototype.initialize.call( this, attributes, options );
 
 							/**
 							 * Posts and pages support trashing, other types don't support a trash


### PR DESCRIPTION
This ensures that plugins which wrap the base `initialize` method will ensure it always will get called. See for example https://github.com/xwp/wp-customize-rest-resources/blob/456308e28a1b495417ca70f30c9da9b630b9ba07/js/rest-resources-manager.js#L49-L57