### PR TITLE
Provide a dedicated build task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -75,6 +75,7 @@ module.exports = function( grunt ) {
 	grunt.loadNpmTasks( 'grunt-contrib-watch' );
 	grunt.loadNpmTasks( 'grunt-contrib-qunit' );
 	grunt.loadNpmTasks( 'grunt-jscs' );
-	grunt.registerTask( 'default', [ 'jshint', 'jscs', 'uglify:js', 'concat:js', 'qunit' ] );
+	grunt.registerTask( 'build', [ 'uglify:js', 'concat:js' ] );
+	grunt.registerTask( 'default', [ 'jshint', 'jscs', 'build', 'qunit' ] );
 	grunt.registerTask( 'test', [ 'qunit:all' ] );
 };


### PR DESCRIPTION
This task only builds the JS files and is useful if you want to update your files but don't have the correct setup for tests (no WordPress install at localhost).