### PR TITLE
Update plugin header to include proper data

### DIFF
--- a/client-js.php
+++ b/client-js.php
@@ -1,8 +1,9 @@
 <?php
 /**
- * Plugin Name: WP-API Client JS.
- *
- * Version 1.0.1
+ * Plugin Name: WP-API Client JS
+ * Plugin URI: https://github.com/WP-API/client-js
+ * Description: Backbone-based JavaScript client for WP API.
+ * Version: 1.0.1
  */
 
 /**


### PR DESCRIPTION
In fffdadea59af252f05ea54e59c3e20bbfe80439f the colon is missing and while I was there I added a description and the plugin URI.